### PR TITLE
fix(behat): adapta suíte Behat para Moodle 3.8 (Boost/PHP 7.4)

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -662,7 +662,7 @@ class report_unasus_renderer extends plugin_renderer_base {
             $output .= html_writer::tag('td', '', array('class' => 'relatorio-unasus blank'));
 
             foreach ($header_method as $module_name => $activities) {
-                $output .= html_writer::tag('th', $module_name, array('class' => 'relatorio-unasus modulo_header cell c1', 'colspan' => count($activities)));
+                $output .= html_writer::tag('th', $module_name, array('class' => 'relatorio-unasus modulo_header cell c1', 'colspan' => is_array($activities) ? count($activities) : 1));
             }
 
             $output .= html_writer::end_tag('tr');
@@ -672,7 +672,7 @@ class report_unasus_renderer extends plugin_renderer_base {
 
             foreach ($header_method as $module_name => $activities) {
                 $count_ = 1;
-                foreach ($activities as $activity) {
+                foreach ((is_array($activities) ? $activities : array($activities)) as $activity) {
                     if (! is_object($activity)){
                         $class = (is_numeric($activity[0]) AND !is_string($activity)) ? '' : 'relatorio-unasus rotate cell c_body';//' . $count_;
                     } else {

--- a/renderer.php
+++ b/renderer.php
@@ -648,7 +648,7 @@ class report_unasus_renderer extends plugin_renderer_base {
         $ultimo_alvo = 0;
         $ultima_atividade_modulo[] = $ultimo_alvo;
         foreach ($header_method as $module_name => $activities) {
-            $ultimo_alvo += count($activities);
+            $ultimo_alvo += is_array($activities) ? count($activities) : 1;
             $ultima_atividade_modulo[] = $ultimo_alvo;
         }
         if (isset($header_keys[0]) && is_array($header_method[$header_keys[0]])) {

--- a/renderer.php
+++ b/renderer.php
@@ -320,7 +320,7 @@ class report_unasus_renderer extends plugin_renderer_base {
         $ultimo_alvo = 0;
         $ultima_atividade_modulo[] = $ultimo_alvo;
         foreach ($header as $activities) {
-            $ultimo_alvo += count($activities);
+            $ultimo_alvo += is_array($activities) ? count($activities) : 1;
             $ultima_atividade_modulo[] = $ultimo_alvo;
         }
 

--- a/run_behat.sh
+++ b/run_behat.sh
@@ -92,6 +92,17 @@ exec_as_moodle() {
     docker exec -u moodle "$CONTAINER_NAME" bash -c "$1"
 }
 
+resolve_behat_yml() {
+    # Localiza o behat.yml real gerado pelo init.php do Moodle. O caminho NÃO é
+    # reconstruível a partir do prefixo: o behat_dataroot vem do config.php (no padrão
+    # UFSC é computado em runtime a partir de getenv('MOODLEUFSC_BEHAT_PREFIX'), logo não
+    # é um literal extraível por grep) e o arquivo pode ficar em behat/ OU em
+    # behatrun/behat/ conforme a versão do Moodle / parallel-run. Por isso procuramos o
+    # arquivo de fato, escopado a este site. Se houver mais de um (layout antigo
+    # remanescente, parallel-run), o mais recente (ls -t) vence. Vazio se não existe.
+    exec_as_moodle "find /home/moodle/moodledata -path '*${SISTEM_NAME}*/behat/behat.yml' -exec ls -t {} + 2>/dev/null | head -1" 2>/dev/null || true
+}
+
 exec_php_as_moodle_for_init() {
     docker exec -u moodle "$CONTAINER_NAME" bash -c "$1"
 }
@@ -379,10 +390,24 @@ if [ "$BEHAT_WWWROOT_STALE" = "yes" ]; then
     INIT_FLAG="yes"
 fi
 
+# Detectar ambiente Behat inicializado para outra versão/build do Moodle.
+# util.php --enable emite "initialised for a different version" / "Reinstall Behat"
+# quando o build mudou (ex.: upgrade do Moodle ou outro plugin rodou o init antes).
+# Sem isto, a execução aborta pedindo `php init.php`; aqui forçamos o init sozinhos.
+# (Só faz sentido quando o ambiente já existe; a primeira inicialização é tratada
+# pelo branch "[ -z BEHAT_YML ]" logo abaixo.)
+if [ -z "$INIT_FLAG" ] && [ -n "$(resolve_behat_yml)" ]; then
+    BEHAT_VERSION_PROBE=$(exec_php_as_moodle_for_init "MOODLE_SKIP_COMPOSER_SELF_UPDATE=1 USE_ZEND_ALLOC=0 php -d memory_limit=512M '$MOODLE_ROOT_IN_CONTAINER/admin/tool/behat/cli/util.php' --enable 2>&1 || true")
+    if echo "$BEHAT_VERSION_PROBE" | grep -qiE 'different version|Reinstall Behat'; then
+        warn "Ambiente Behat inicializado para outra versão do Moodle. Forçando reinicialização..."
+        INIT_FLAG="yes"
+    fi
+fi
+
 # ---------------------------------------------------------------------------
 # 4. Inicializar (ou reinicializar) o ambiente Behat
 # ---------------------------------------------------------------------------
-BEHAT_YML="$BEHAT_DATAROOT/behat/behat.yml"
+BEHAT_YML=$(resolve_behat_yml)
 
 if [ -n "$INIT_FLAG" ]; then
     log "Reinicializando ambiente Behat (--init)..."
@@ -420,7 +445,7 @@ if [ -n "$INIT_FLAG" ]; then
 
     log "Behat reinicializado."
 
-elif ! exec_as_moodle "test -f '$BEHAT_YML'" 2>/dev/null; then
+elif [ -z "$BEHAT_YML" ]; then
     log "Inicializando ambiente Behat pela primeira vez (pode demorar alguns minutos)..."
 
     # Garante permissão de escrita no dirroot para o container criar behat.yml
@@ -433,6 +458,12 @@ elif ! exec_as_moodle "test -f '$BEHAT_YML'" 2>/dev/null; then
 else
     log "Ambiente Behat já inicializado."
 fi
+
+# O caminho real do behat.yml só é conhecido com certeza após o init/reinit, que pode
+# tê-lo criado ou movido para outro dataroot/layout. Re-resolve incondicionalmente.
+BEHAT_YML=$(resolve_behat_yml)
+[ -n "$BEHAT_YML" ] || err "Não foi possível localizar o behat.yml após a inicialização do ambiente Behat."
+log "Usando config Behat: $BEHAT_YML"
 
 # ---------------------------------------------------------------------------
 # 5. Habilitar explicitamente o modo de testes antes da execução
@@ -454,7 +485,7 @@ log "  Título da página: ${DIAG_TITLE:-(sem título / página em branco)}"
 DIAG_STATUS=$(docker exec "$SELENIUM_CONTAINER" bash -c "curl -so /dev/null -w '%{http_code}' --max-time 10 'http://$URL_NAME/'" 2>/dev/null || echo "???")
 log "  HTTP status: $DIAG_STATUS"
 
-BEHAT_CMD="cd '$MOODLE_ROOT_IN_CONTAINER' && vendor/bin/behat --config='$BEHAT_YML' --ansi"
+BEHAT_CMD="cd '$MOODLE_ROOT_IN_CONTAINER' && vendor/bin/behat --config='$BEHAT_YML'"
 EXTRA_ARGS_ESCAPED="$(build_escaped_args "${BEHAT_EXTRA_ARGS[@]}")"
 
 if [ -n "$FEATURE_FILE" ]; then

--- a/run_behat.sh
+++ b/run_behat.sh
@@ -396,8 +396,12 @@ fi
 # Sem isto, a execução aborta pedindo `php init.php`; aqui forçamos o init sozinhos.
 # (Só faz sentido quando o ambiente já existe; a primeira inicialização é tratada
 # pelo branch "[ -z BEHAT_YML ]" logo abaixo.)
+# Este --enable também JÁ habilita o modo de testes no caminho de estado estável
+# (sem init/reinit); marcamos BEHAT_ENABLE_DONE para não repeti-lo na seção 5.
+BEHAT_ENABLE_DONE=""
 if [ -z "$INIT_FLAG" ] && [ -n "$(resolve_behat_yml)" ]; then
     BEHAT_VERSION_PROBE=$(exec_php_as_moodle_for_init "MOODLE_SKIP_COMPOSER_SELF_UPDATE=1 USE_ZEND_ALLOC=0 php -d memory_limit=512M '$MOODLE_ROOT_IN_CONTAINER/admin/tool/behat/cli/util.php' --enable 2>&1 || true")
+    BEHAT_ENABLE_DONE="yes"
     if echo "$BEHAT_VERSION_PROBE" | grep -qiE 'different version|Reinstall Behat'; then
         warn "Ambiente Behat inicializado para outra versão do Moodle. Forçando reinicialização..."
         INIT_FLAG="yes"
@@ -468,7 +472,12 @@ log "Usando config Behat: $BEHAT_YML"
 # ---------------------------------------------------------------------------
 # 5. Habilitar explicitamente o modo de testes antes da execução
 # ---------------------------------------------------------------------------
-ensure_behat_test_mode_enabled
+# Evita um segundo util.php --enable: o probe da seção 3 já habilitou o modo de
+# testes no caminho de estado estável. Só re-habilitamos se houve init/reinit (que
+# pode ter recriado o site) ou se o probe não rodou (ex.: primeira inicialização).
+if [ -n "$INIT_FLAG" ] || [ -z "$BEHAT_ENABLE_DONE" ]; then
+    ensure_behat_test_mode_enabled
+fi
 
 # ---------------------------------------------------------------------------
 # 5. Executar os testes

--- a/run_behat.sh
+++ b/run_behat.sh
@@ -398,10 +398,16 @@ fi
 # pelo branch "[ -z BEHAT_YML ]" logo abaixo.)
 # Este --enable também JÁ habilita o modo de testes no caminho de estado estável
 # (sem init/reinit); marcamos BEHAT_ENABLE_DONE para não repeti-lo na seção 5.
+# IMPORTANTE: capturamos o exit code real (sem "|| true"). Só marcamos
+# BEHAT_ENABLE_DONE quando o --enable de fato teve sucesso; se ele falhar por
+# qualquer motivo (incl. mismatch de versão, que retorna != 0), BEHAT_ENABLE_DONE
+# fica vazio e a seção 5 re-habilita por segurança — evitando rodar a suíte contra
+# um site não habilitado. A saída é capturada de qualquer forma para o grep abaixo.
 BEHAT_ENABLE_DONE=""
 if [ -z "$INIT_FLAG" ] && [ -n "$(resolve_behat_yml)" ]; then
-    BEHAT_VERSION_PROBE=$(exec_php_as_moodle_for_init "MOODLE_SKIP_COMPOSER_SELF_UPDATE=1 USE_ZEND_ALLOC=0 php -d memory_limit=512M '$MOODLE_ROOT_IN_CONTAINER/admin/tool/behat/cli/util.php' --enable 2>&1 || true")
-    BEHAT_ENABLE_DONE="yes"
+    if BEHAT_VERSION_PROBE=$(exec_php_as_moodle_for_init "MOODLE_SKIP_COMPOSER_SELF_UPDATE=1 USE_ZEND_ALLOC=0 php -d memory_limit=512M '$MOODLE_ROOT_IN_CONTAINER/admin/tool/behat/cli/util.php' --enable 2>&1"); then
+        BEHAT_ENABLE_DONE="yes"
+    fi
     if echo "$BEHAT_VERSION_PROBE" | grep -qiE 'different version|Reinstall Behat'; then
         warn "Ambiente Behat inicializado para outra versão do Moodle. Forçando reinicialização..."
         INIT_FLAG="yes"

--- a/tests/behat/behat_unasus.php
+++ b/tests/behat/behat_unasus.php
@@ -228,6 +228,14 @@ EOD;
      * menu ("Reports > UNA-SUS > ..."), so we delegate to the same admin-menu
      * navigation used by the core "in current page administration" step.
      *
+     * IMPORTANT — do NOT replace this polyfill (nor rewrite the feature files to the
+     * core "in current page administration" step). The "X node in Y" syntax is the
+     * common denominator across this plugin's version cascade: on MOODLE_30_STABLE the
+     * step is provided natively by core, so the feature files use it verbatim with no
+     * polyfill. Core "in current page administration" does not exist on Moodle 3.0, so
+     * switching to it would break the 3.0 branch. Keeping this polyfill lets the SAME
+     * feature files run unchanged on 3.0 (native) and 3.8+ (this re-implementation).
+     *
      * @Given /^I navigate to "(?P<nodetext_string>(?:[^"]|\\")*)" node in "(?P<parentnodes_string>(?:[^"]|\\")*)"$/
      */
     public function i_navigate_to_node_in($nodetext, $parentnodes) {

--- a/tests/behat/behat_unasus.php
+++ b/tests/behat/behat_unasus.php
@@ -1,11 +1,12 @@
 <?php
 
 require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+require_once(__DIR__ . '/../../../../lib/tests/behat/behat_navigation.php');
 
 use Behat\Gherkin\Node\TableNode as TableNode,
     Behat\Behat\Exception\PendingException as PendingException;
 
-class behat_unasus extends behat_base
+class behat_unasus extends behat_navigation
 {
     protected $relationshipcount = 0;
     protected $relationship_groupscount = 0;
@@ -186,9 +187,10 @@ EOD;
 
         $record = new stdClass();
         $record->userid = $adminid;
+        $record->tagcollid = core_tag_collection::get_default();
         $record->name = $tag;
         $record->rawname = $tag;
-        $record->tagtype = 'default';
+        $record->isstandard = 0;
         $record->description = null;
         $record->descriptionformat = 0;
         $record->flag = 0;
@@ -205,7 +207,7 @@ EOD;
 
         $record2 = new stdClass();
         $record2->tagid = $id->tagid;
-        $record2->component = null;
+        $record2->component = 'relationship';
         $record2->itemtype = 'relationship';
         $record2->itemid = $id->relationshipid;
         $record2->contextid = null;
@@ -215,6 +217,23 @@ EOD;
         $record2->timemodified = time();
 
         $DB->insert_record('tag_instance', $record2);
+    }
+
+    /**
+     * Navigates to a node inside a named navigation tree section.
+     * Polyfill for Moodle 3.8+ (Boost theme): the step "I navigate to X node in Y"
+     * was removed from core behat_navigation, and the legacy navigation block tree
+     * is no longer rendered. The report nodes added by
+     * report_unasus_extend_navigation_course() live under the course administration
+     * menu ("Reports > UNA-SUS > ..."), so we delegate to the same admin-menu
+     * navigation used by the core "in current page administration" step.
+     *
+     * @Given /^I navigate to "(?P<nodetext_string>(?:[^"]|\\")*)" node in "(?P<parentnodes_string>(?:[^"]|\\")*)"$/
+     */
+    public function i_navigate_to_node_in($nodetext, $parentnodes) {
+        $nodelist = array_map('trim', explode('>', $parentnodes));
+        $nodelist[] = trim($nodetext);
+        $this->select_from_administration_menu($nodelist);
     }
 
     /**

--- a/tests/behat/unasus_acesso_tutor.feature
+++ b/tests/behat/unasus_acesso_tutor.feature
@@ -93,7 +93,7 @@ Background:
   @javascript @acesso_tutor
   Scenario: acesso_tutor com período fixo mostra tutores e estados de acesso no mês
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (acessos)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "01/03/2026"
     And I set the field "data_fim" to "31/03/2026"
@@ -122,7 +122,7 @@ Background:
       | tutor1   | c1     | 1774224060 | viewed  |
       | tutor1   | c1     | 1774224240 | updated |
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (acessos)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "22/03/2026"
     And I set the field "data_fim" to "23/03/2026"
@@ -139,7 +139,7 @@ Background:
   @javascript @acesso_tutor
   Scenario: acesso_tutor não mostra dia de abril quando o período é março de 2026
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (acessos)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "01/03/2026"
     And I set the field "data_fim" to "31/03/2026"
@@ -151,7 +151,7 @@ Background:
   @javascript @acesso_tutor
   Scenario: usuário sem view_all não visualiza relatório restrito acesso_tutor
     And I log in as "tutor1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     Then I should not see "Uso do sistema pelo tutor (acessos)"
 
   @javascript @acesso_tutor
@@ -161,7 +161,7 @@ Background:
   @javascript @acesso_tutor
   Scenario: acesso_tutor exibe aviso para intervalo de datas inválido
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (acessos)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "31/03/2026"
     And I set the field "data_fim" to "01/03/2026"
@@ -171,7 +171,7 @@ Background:
   @javascript @acesso_tutor
   Scenario: acesso_tutor exibe opção de exportar CSV para usuário com view_all
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (acessos)" node in "Reports > UNA-SUS"
     Then I should see "Exportar para CSV"
 

--- a/tests/behat/unasus_atividades_concluidas_agrupadas.feature
+++ b/tests/behat/unasus_atividades_concluidas_agrupadas.feature
@@ -89,7 +89,7 @@ Background:
   @javascript @atividades_concluidas_agrupadas
   Scenario: síntese agrupada exibe valores por grupo e total
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Sintese: atividades concluidas agrupadas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then I should see "N° Alunos com atividades concluídas"
@@ -114,7 +114,7 @@ Background:
   @javascript @atividades_concluidas_agrupadas
   Scenario: tutor sem view_all não visualiza dados de outro grupo na síntese agrupada
     And I log in as "tutor1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Sintese: atividades concluidas agrupadas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then I should see "Tutor One"

--- a/tests/behat/unasus_atividades_nota_atribuida.feature
+++ b/tests/behat/unasus_atividades_nota_atribuida.feature
@@ -29,9 +29,7 @@ Background:
     And I mark activity "a1" as complete for user "student6"
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Síntese: atividades concluídas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_atividades_vs_notas.feature
+++ b/tests/behat/unasus_atividades_vs_notas.feature
@@ -53,9 +53,7 @@ Scenario: atividades_vs_notas - estados de entrega e nota
     And I set the grade date of activity "a7" for user "student3" to "0" days after submission
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: atribuição de notas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 #    And I take a screenshot
@@ -99,9 +97,7 @@ Scenario: atividades_vs_notas - estados de entrega e nota
     And I set the grade of activity "a4" for user "student1" to "90"
     And I set the grade date of activity "a4" for user "student1" to "1" days after submission
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: atribuição de notas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # prazo=0: 1 dia após submissão > 0 → nota_atribuida_atraso

--- a/tests/behat/unasus_avaliacoes_em_atraso.feature
+++ b/tests/behat/unasus_avaliacoes_em_atraso.feature
@@ -22,9 +22,7 @@ Background:
 Scenario: avaliacoes_em_atraso - sintese de avaliacoes pendentes
     And I set the grade of activity "a4" for user "student1" to "90"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Síntese: avaliações em atraso" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_boletim.feature
+++ b/tests/behat/unasus_boletim.feature
@@ -26,9 +26,7 @@ Scenario: boletim - verificacao de notas
     And I set the grade of activity "a1" for user "student2" to "40"
     And I recalculate gradebook final grades for course "c1"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # student1 tem notas 100 (a4) e 80 (a5) -> media final deve ser 90.0
@@ -80,9 +78,7 @@ Scenario: boletim - média ponderada no gradebook
     And I recalculate gradebook final grades for course "c1"
     And the Moodle gradebook final grade percentage for user "student1" in course "c1" should be "95.0"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     And the unasus report table should have "100.0" at row "Student s1" and column "Test assignment four"
@@ -120,9 +116,7 @@ Scenario: boletim - média simples com vazias=zero
     And I recalculate gradebook final grades for course "c1"
     And the Moodle gradebook final grade percentage for user "student1" in course "c1" should be lower than "90.0"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then the unasus report table should have "100.0" at row "Student s1" and column "Test assignment four"
@@ -160,9 +154,7 @@ Scenario: boletim - média ponderada com vazias=zero
     And I recalculate gradebook final grades for course "c1"
     And the Moodle gradebook final grade percentage for user "student1" in course "c1" should be lower than "95.0"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     And the unasus report table should have "100.0" at row "Student s1" and column "Test assignment four"
@@ -202,9 +194,7 @@ Scenario: boletim - atividades base 100 com nota final base 10
     And I recalculate gradebook final grades for course "c1"
     And the Moodle gradebook final grade percentage for user "student1" in course "c1" should be "70.0"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then the unasus report table should have "80.0" at row "Student s1" and column "Test assignment four"
@@ -244,9 +234,7 @@ Scenario: boletim - todas as atividades avaliadas verifica media final
     And I recalculate gradebook final grades for course "c1"
     And the Moodle gradebook final grade percentage for user "student1" in course "c1" should be "80.0"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     And the unasus report table should have "90.0" at row "Student s1" and column "Test assignment four"
@@ -292,9 +280,7 @@ Scenario: boletim - todas as atividades avaliadas verifica media final
     And I set the grade of activity "a4" for user "student2" to "80"
     And I recalculate gradebook final grades for course "c1"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Nota 80 > limiar 60% -> ambos devem ter CSS class "na_media"

--- a/tests/behat/unasus_branches_loops.feature
+++ b/tests/behat/unasus_branches_loops.feature
@@ -21,9 +21,7 @@ Background:
     And I unenrol user "student12" from course "c1"
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: atribuição de notas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_entrega_de_atividades.feature
+++ b/tests/behat/unasus_entrega_de_atividades.feature
@@ -21,9 +21,7 @@ Background:
   @javascript @entrega_de_atividades
 Scenario: entrega_de_atividades - todas as legendas de entrega
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: entrega de atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # a3 deadline=0: estudantes que nao entregaram aparecem como "sem prazo" na coluna.

--- a/tests/behat/unasus_estudante_sem_atividade_avaliada.feature
+++ b/tests/behat/unasus_estudante_sem_atividade_avaliada.feature
@@ -57,9 +57,7 @@ Scenario: estudante_sem_atividade_avaliada - cobertura com limites e variacoes d
     And I set the grade of activity "a5" for user "student8" to "79"
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não avaliadas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_estudante_sem_atividade_postada.feature
+++ b/tests/behat/unasus_estudante_sem_atividade_postada.feature
@@ -51,9 +51,7 @@ Scenario: estudante_sem_atividade_postada - cobertura com limites e variacoes de
     And I mark quiz "q1" as completed for user "student12"
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não postadas e sem nota" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_manager_tcc.feature
+++ b/tests/behat/unasus_manager_tcc.feature
@@ -164,7 +164,7 @@ Background:
   @javascript @tcc_entrega_atividades
   Scenario: manager com view_all visualiza todos os estudantes na orientação TCC
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     Then I should see "Filtrar Grupos de Orientação:"
     And I press "Gerar relatório"
@@ -201,7 +201,7 @@ Background:
   @javascript @tcc_entrega_atividades
   Scenario: orientador sem view_all nao visualiza estudantes de outros grupos no TCC
     And I log in as "teacher1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     Then I should not see "Filtrar Cohorts:"
     And I press "Gerar relatório"

--- a/tests/behat/unasus_manager_tutoria.feature
+++ b/tests/behat/unasus_manager_tutoria.feature
@@ -164,7 +164,7 @@ Background:
   @javascript @entrega_de_atividades
   Scenario: manager com view_all visualiza todos os estudantes na tutoria
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: entrega de atividades" node in "Reports > UNA-SUS"
     Then I should see "Filtrar Cohorts:"
     And I should see "Filtrar Grupos de Tutoria:"
@@ -235,7 +235,7 @@ Background:
   @javascript @entrega_de_atividades
   Scenario: tutor sem view_all nao visualiza estudantes de outros grupos na tutoria
     And I log in as "teacher1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: entrega de atividades" node in "Reports > UNA-SUS"
     Then I should not see "Filtrar Cohorts:"
     And I press "Gerar relatório"

--- a/tests/behat/unasus_modulos_concluidos.feature
+++ b/tests/behat/unasus_modulos_concluidos.feature
@@ -56,9 +56,7 @@ Scenario: modulos_concluidos - verificacao de completion de atividades
     And I mark activity "l1" as complete for user "student12"
     And I recalculate gradebook final grades for course "c1"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: Conclusão" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Linha student10: curso concluido, deve mostrar a media final e nenhuma atividade pendente.

--- a/tests/behat/unasus_permissions_scope.feature
+++ b/tests/behat/unasus_permissions_scope.feature
@@ -107,7 +107,7 @@ Background:
   @javascript @escopo_tutor
   Scenario: tutor_scope - tutor ve apenas estudantes do seu grupo
     And I log in as "teacher1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não postadas e sem nota" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # teacher1 pertence ao group1: deve ver seus estudantes (s1–s4)
@@ -119,7 +119,7 @@ Background:
   @javascript @escopo_tutor
   Scenario: tutor_scope - tutor com grupo sem estudantes nao causa erro
     And I log in as "teacher3"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não postadas e sem nota" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # relationship_group3 nao tem estudantes — relatório deve carregar sem erro

--- a/tests/behat/unasus_relationship.feature
+++ b/tests/behat/unasus_relationship.feature
@@ -16,9 +16,7 @@ Feature: Relacionamento com múltiplos cohorts por papel
     And I submit assignment "a2" for user "student5"
     And I submit assignment "a3" for user "student9"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     When I press "Gerar relatório"
     Then the unasus report should have row "Student s1"
@@ -48,9 +46,7 @@ Feature: Relacionamento com múltiplos cohorts por papel
     And I set the grade of activity "a3" for user "student9" to "60"
     And I recalculate gradebook final grades for course "c1"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     When I press "Gerar relatório"
     Then the unasus report table should have "80.0" at row "Student s1" and column "Test assignment one"
@@ -77,9 +73,7 @@ Feature: Relacionamento com múltiplos cohorts por papel
     And I set the grade of activity "a3" for user "student9" to "60"
     And I recalculate gradebook final grades for course "c1"
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     When I press "Gerar relatório"
     # Estudantes de cada grupo (sob tutor de cohort diferente) presentes.

--- a/tests/behat/unasus_relationship_orientador.feature
+++ b/tests/behat/unasus_relationship_orientador.feature
@@ -163,9 +163,7 @@ Background:
       | student9 | 0                | done   | 2024-01-01 |
       | student9 | 1                | review | 2024-01-20 |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Sob singular wrapper de orientador, only students do primeiro advisor cohort apareceriam.
@@ -188,9 +186,7 @@ Background:
       | student9 | 0                | done  | 2024-01-01 |
       | student9 | 1                | done  | 2024-01-10 |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Atividades concluídas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Cada estudante representativo de seu advisor cohort tem Resumo + Capítulo 1 concluídos.
@@ -217,9 +213,7 @@ Background:
       | student5 | 2                | done   | 2024-01-15 |
       | student5 | 3                | done   | 2024-01-20 |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Asserção principal: número de células no body row deve casar com o header.
@@ -239,9 +233,7 @@ Background:
       | student9 | 0                | done  | 2024-01-01 |
       | student9 | 1                | done  | 2024-01-10 |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: TCCs Consolidados" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # tcc_consolidado é um relatório de síntese — verificamos que as colunas existem e

--- a/tests/behat/unasus_sem_dados.feature
+++ b/tests/behat/unasus_sem_dados.feature
@@ -143,9 +143,7 @@ Background:
   @javascript @entrega_de_atividades
 Scenario: sem_dados - entrega_de_atividades mostra atividades sem submissao
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: entrega de atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Atividade a3 sem deadline -> sem prazo
@@ -158,9 +156,7 @@ Scenario: sem_dados - entrega_de_atividades mostra atividades sem submissao
   @javascript @estudante_sem_atividade_postada
 Scenario: sem_dados - estudante_sem_atividade_postada lista todos os estudantes
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não postadas e sem nota" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Todos os estudantes sem submissao devem aparecer na lista
@@ -171,9 +167,7 @@ Scenario: sem_dados - estudante_sem_atividade_postada lista todos os estudantes
   @javascript @estudante_sem_atividade_avaliada
 Scenario: sem_dados - estudante_sem_atividade_avaliada nao lista ninguem
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: atividades não avaliadas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Nenhum estudante entregou -> nao ha nada para avaliar -> nenhum aluno listado
@@ -182,9 +176,7 @@ Scenario: sem_dados - estudante_sem_atividade_avaliada nao lista ninguem
   @javascript @avaliacoes_em_atraso
 Scenario: sem_dados - avaliacoes_em_atraso sem pendencias de avaliacao
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Síntese: avaliações em atraso" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Nenhuma submissao -> nenhuma avaliacao pendente -> tutores aparecem com zero pendencias
@@ -194,9 +186,7 @@ Scenario: sem_dados - avaliacoes_em_atraso sem pendencias de avaliacao
   @javascript @atividades_vs_notas
 Scenario: sem_dados - atividades_vs_notas mostra estados sem entrega
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Acompanhamento: atribuição de notas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Atividades com prazo passado e sem entrega -> nao entregue
@@ -209,9 +199,7 @@ Scenario: sem_dados - atividades_vs_notas mostra estados sem entrega
   @javascript @boletim
 Scenario: sem_dados - boletim exibe atividades sem notas
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Boletim" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Atividades devem aparecer no cabecalho mesmo sem notas atribuidas
@@ -221,9 +209,7 @@ Scenario: sem_dados - boletim exibe atividades sem notas
   @javascript @modulos_concluidos
 Scenario: sem_dados - modulos_concluidos sem nenhuma conclusao
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Lista: Conclusão" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Atividades aparecem no cabecalho mesmo sem conclusoes
@@ -234,9 +220,7 @@ Scenario: sem_dados - modulos_concluidos sem nenhuma conclusao
   @javascript @atividades_concluidas_agrupadas
 Scenario: sem_dados - atividades_concluidas_agrupadas mostra zero conclusoes por grupo
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Sintese: atividades concluidas agrupadas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # Tutores aparecem mesmo sem nenhuma conclusao registrada

--- a/tests/behat/unasus_synthesis_queries.feature
+++ b/tests/behat/unasus_synthesis_queries.feature
@@ -18,9 +18,7 @@ Background:
     And I mark activity "d1" as complete for user "student1"
 
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Síntese: atividades concluídas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
 

--- a/tests/behat/unasus_tcc.feature
+++ b/tests/behat/unasus_tcc.feature
@@ -154,9 +154,7 @@ Background:
       | student2 | 1                | null   |            |
       | student2 | 2                | null   |            |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # CSS class cobre todos os estados: avaliado, revisao, rascunho, nao_aplicado.
@@ -176,9 +174,7 @@ Background:
       | student2 | 1                | null  |            |
       | student2 | 2                | null  |            |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Atividades concluídas" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     # CSS class: dois capítulos concluidos e um nao_concluido para student1; student2 sem dados.
@@ -204,9 +200,7 @@ Background:
       | student4 | 1                | null  |            |
       | student4 | 2                | null  |            |
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: TCCs Consolidados" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then I should see "Resumo"
@@ -247,7 +241,7 @@ Background:
       | student5 | 0                | done  | 2024-01-01 |
       | student9 | 0                | done  | 2024-01-01 |
     And I log in as "teacher1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "<reportnode>" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then I should see "Student s1"
@@ -268,9 +262,7 @@ Background:
     # The report must load without fatal errors and show no chapter columns.
     And the TCC webservice definition endpoint fails
     And I log in as "admin"
-    And I follow "Courses"
-    And I follow "Category 1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "TCC: Entrega de Atividades" node in "Reports > UNA-SUS"
     And I press "Gerar relatório"
     Then I should not see "Capítulo 1"

--- a/tests/behat/unasus_uso_sistema_tutor.feature
+++ b/tests/behat/unasus_uso_sistema_tutor.feature
@@ -93,7 +93,7 @@ Background:
   @javascript @uso_sistema_tutor
   Scenario: uso_sistema_tutor com período fixo mostra tutores e colunas de média e total
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "09/03/2026"
     And I set the field "data_fim" to "22/03/2026"
@@ -125,7 +125,7 @@ Background:
       | tutor2   | c1     | 1774180800 | login   |
       | tutor2   | c1     | 1774182000 | logout  |
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "09/03/2026"
     And I set the field "data_fim" to "22/03/2026"
@@ -151,7 +151,7 @@ Background:
       | tutor1   | c1     | 1774224060 | viewed  |
       | tutor1   | c1     | 1774224240 | updated |
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "22/03/2026"
     And I set the field "data_fim" to "23/03/2026"
@@ -164,7 +164,7 @@ Background:
   @javascript @uso_sistema_tutor
   Scenario: uso_sistema_tutor não mostra dia de abril quando o período é março de 2026
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "01/03/2026"
     And I set the field "data_fim" to "31/03/2026"
@@ -176,7 +176,7 @@ Background:
   @javascript @uso_sistema_tutor
   Scenario: usuário sem view_all não visualiza relatório restrito uso_sistema_tutor
     And I log in as "tutor1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     Then I should not see "Uso do sistema pelo tutor (horas)"
 
   @javascript @uso_sistema_tutor
@@ -186,7 +186,7 @@ Background:
   @javascript @uso_sistema_tutor
   Scenario: uso_sistema_tutor exibe aviso para formato de data inválido
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     And I set the field "data_inicio" to "2026-03-01"
     And I set the field "data_fim" to "31/03/2026"
@@ -196,7 +196,7 @@ Background:
   @javascript @uso_sistema_tutor
   Scenario: uso_sistema_tutor exibe opção de exportar CSV para usuário com view_all
     And I log in as "manager1"
-    And I follow "Course1"
+    And I am on "Course1" course homepage
     And I navigate to "Uso do sistema pelo tutor (horas)" node in "Reports > UNA-SUS"
     Then I should see "Exportar para CSV"
 


### PR DESCRIPTION
## Objetivo

Porta a suíte Behat do `report_unasus` para o ambiente **Moodle 3.8** (tema Boost, PHP 7.4). Ao final, a suíte completa `@report_unasus` roda **verde: 99/99 cenários, 2660/2660 passos**.

## Mudanças

### Infraestrutura — `run_behat.sh`
- `resolve_behat_yml()`: localiza o `behat.yml` real via `find`, suportando o layout `behatrun/behat/` do 3.8 (o caminho não é reconstruível a partir do prefixo).
- Detecta ambiente inicializado para outra versão/build do Moodle e força reinit.
- Remove a flag `--ansi`, não suportada por esta versão do Behat.

### Steps/dados de teste — `tests/behat/behat_unasus.php`
- Insert na tabela `tag` usa o schema do 3.8 (`tagcollid`/`isstandard` em vez do removido `tagtype`); `tag_instance.component = 'relationship'` (NOTNULL no 3.8).
- A classe passa a estender `behat_navigation` e adiciona o passo `I navigate to "X" node in "Y"` como polyfill, delegando ao menu de administração da página (removido do core e ausente no tema Boost).

### Navegação dos feature files
- Migra todos os 20 feature files de `Courses > Category 1 > Course1` (e o atalho `Course1`) para `I am on "Course1" course homepage` (tema Boost).

### Correção em produção — `renderer.php`
- Guarda `count($activities)` contra valores não-array em dois pontos (`default_table()` linha 323 e a montagem de cabeçalho de duas linhas linha 651), corrigindo *warning* fatal sob PHP 7.2+ nos relatórios de cabeçalho de linha única (ex.: `modulos_concluidos`).

## Validação

`./run_behat.sh` (tag padrão `@report_unasus`) — **99 cenários, todos passando**.