### PR TITLE
fix(behat): resolve behat.yml por caminho determinístico (closes #14)

### DIFF
--- a/run_behat.sh
+++ b/run_behat.sh
@@ -93,14 +93,23 @@ exec_as_moodle() {
 }
 
 resolve_behat_yml() {
-    # Localiza o behat.yml real gerado pelo init.php do Moodle. O caminho NÃO é
-    # reconstruível a partir do prefixo: o behat_dataroot vem do config.php (no padrão
-    # UFSC é computado em runtime a partir de getenv('MOODLEUFSC_BEHAT_PREFIX'), logo não
-    # é um literal extraível por grep) e o arquivo pode ficar em behat/ OU em
-    # behatrun/behat/ conforme a versão do Moodle / parallel-run. Por isso procuramos o
-    # arquivo de fato, escopado a este site. Se houver mais de um (layout antigo
-    # remanescente, parallel-run), o mais recente (ls -t) vence. Vazio se não existe.
-    exec_as_moodle "find /home/moodle/moodledata -path '*${SISTEM_NAME}*/behat/behat.yml' -exec ls -t {} + 2>/dev/null | head -1" 2>/dev/null || true
+    # Localiza o behat.yml real gerado pelo init.php do Moodle. O behat_dataroot é
+    # determinístico: o bloco de correção (ver "behat_dataroot desatualizado" abaixo)
+    # garante que o config.php use exatamente $BEHAT_DATAROOT. Só o subdiretório varia
+    # por versão/layout: behatrun/behat/ (3.8 / parallel-run) ou behat/ (run único,
+    # estilo MOODLE_30_STABLE). Testamos os caminhos exatos, do mais específico (3.8)
+    # para o mais geral, para que um behat/behat.yml obsoleto de run único não vença o
+    # do 3.8. Escopado ao dataroot deste site — sem glob de substring (que casaria
+    # sites vizinhos como local-unasus30) nem ls -t (que escolheria um shard arbitrário).
+    # Vazio se nenhum existir.
+    local sub yml
+    for sub in behatrun/behat behat; do
+        yml="$BEHAT_DATAROOT/$sub/behat.yml"
+        if exec_as_moodle "test -f '$yml'" 2>/dev/null; then
+            echo "$yml"
+            return 0
+        fi
+    done
 }
 
 exec_php_as_moodle_for_init() {


### PR DESCRIPTION
Corrige o problema descrito na #14.

## Problema

`resolve_behat_yml()` (introduzida em #13) localizava o `behat.yml` com um `find` de **substring sem âncoras** + `ls -t` para desempate:

```bash
find /home/moodle/moodledata -path '*${SISTEM_NAME}*/behat/behat.yml' -exec ls -t {} + 2>/dev/null | head -1
```

Podia resolver o arquivo errado: a substring casa sites vizinhos (`local-unasus3` vs `local-unasus30`) e shards de parallel-run (`behatrun{N}/`) coexistentes faziam o `ls -t` escolher um arquivo arbitrário — silenciosamente, sem erro do resolvedor.

## Solução

O `$BEHAT_DATAROOT` é determinístico neste fluxo: o bloco de correção do `behat_dataroot` já reescreve o `config.php` para usar exatamente `$BEHAT_DATAROOT`. Só o subdiretório varia por layout. A função passa a testar os caminhos **exatos**, ancorados no dataroot deste site, do mais específico para o mais geral:

```bash
for sub in behatrun/behat behat; do
    yml="$BEHAT_DATAROOT/$sub/behat.yml"
    if exec_as_moodle "test -f '$yml'" 2>/dev/null; then
        echo "$yml"; return 0
    fi
done
```

- Sem glob de substring → não casa sites vizinhos.
- Sem `ls -t` arbitrário → precedência explícita (`behatrun/behat` antes de `behat`, para um `behat/behat.yml` obsoleto de run único não vencer o do 3.8).
- Escopo exato ao dataroot deste site.

## Validação

Smoke (`unasus_sem_dados.feature`): o resolvedor localiza `.../bht_local-unasus3/behatrun/behat/behat.yml` corretamente e a suíte sobe normalmente.

## Nota de base

Direcionado a `fix/behat-resolve-yml-e-tag-mdl38` (PR #13), pois é onde o código de `resolve_behat_yml` vive — ainda não está no `main`. Reapontar para `main` após o merge da #13, se preferir.